### PR TITLE
Grunt task to generate list_of_tests.js

### DIFF
--- a/mocha-boilerplate/grunt.js
+++ b/mocha-boilerplate/grunt.js
@@ -8,7 +8,7 @@ module.exports = function(grunt) {
     },
     watch: {
       files: '<config:lint.files>',
-      tasks: 'lint qunit'
+      tasks: 'lint test'
     },
     jshint: {
       options: {
@@ -32,6 +32,8 @@ module.exports = function(grunt) {
   });
 
   grunt.loadNpmTasks('grunt-mocha');
-  grunt.registerTask('default', 'lint mocha');
+  grunt.loadTasks('tasks');
 
+  grunt.registerTask('test', 'gatherTests mocha');
+  grunt.registerTask('default', 'lint test');
 };

--- a/mocha-boilerplate/tasks/gather_tests.js
+++ b/mocha-boilerplate/tasks/gather_tests.js
@@ -1,0 +1,36 @@
+module.exports = function( grunt ) {
+	
+	grunt.registerTask( 'gatherTests', function() {
+		var fs = require( 'fs' ),
+			path = require( 'path' ),
+			testDir = 'tests',
+			tests = []
+
+		// List the files in the tests directory.
+		fs.readdirSync( testDir ).filter( function( file ) {
+
+			// Keep the .js files
+			return file.substr( -3 ) === '.js';
+		
+		}).forEach( function( file ) {
+
+			// Add the file to the list of tests.
+			tests.push(
+				path.join( testDir, file )
+			);
+		});
+
+		// Format the test name as a RequireJS module.
+		tests = tests.map( function( test ) {
+			return "'" + test.split('.')[0] + "'";
+		}).join(",\n    ");
+
+		// Write the list of tests to file
+		fs.writeFileSync('list_of_tests.js', "define(function() {\n" +
+				"  return [\n" +
+				"    " + tests + "\n" +
+				"  ];\n" +
+				"});\n"
+		);
+	});
+};

--- a/mocha-boilerplate/tasks/gather_tests.js
+++ b/mocha-boilerplate/tasks/gather_tests.js
@@ -4,7 +4,7 @@ module.exports = function( grunt ) {
 		var fs = require( 'fs' ),
 			path = require( 'path' ),
 			testDir = 'tests',
-			tests = []
+			tests = [];
 
 		// List the files in the tests directory.
 		fs.readdirSync( testDir ).filter( function( file ) {
@@ -20,7 +20,7 @@ module.exports = function( grunt ) {
 			);
 		});
 
-		// Format the test name as a RequireJS module.
+		// Format the test names as RequireJS modules.
 		tests = tests.map( function( test ) {
 			return "'" + test.split('.')[0] + "'";
 		}).join(",\n    ");


### PR DESCRIPTION
I threw together a grunt task, `gatherTests`, to generate list_of_tests.js in the mocha-boilerplate. It's wired up to the `mocha` task using an alias `test` task. Perhaps there is a cleaner way to structure the tasks for this. I'm open to alternatives.

At any rate, I'm interested in any feedback you might have.

Cheers.
